### PR TITLE
Fix file upload and enrichment logging

### DIFF
--- a/pages/upload.js
+++ b/pages/upload.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 
@@ -7,6 +7,15 @@ export default function Upload() {
   const [status, setStatus] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [cleansedDataStoreId, setCleansedDataStoreId] = useState(null);
+  const fileInputRef = useRef(null);
+  const pollingIntervalRef = useRef(null);
+
+  const clearPolling = () => {
+    if (pollingIntervalRef.current) {
+      clearInterval(pollingIntervalRef.current);
+      pollingIntervalRef.current = null;
+    }
+  };
 
   const handleFileChange = (e) => {
     setFile(e.target.files[0]);
@@ -20,11 +29,16 @@ export default function Upload() {
 
     setIsLoading(true);
     setStatus('Uploading file...');
+    setCleansedDataStoreId(null);
 
     const formData = new FormData();
-    formData.append('file', file);
+    const originalFileName = file.name?.trim() ?? 'uploaded-file.json';
+    const sourceUri = `file-upload:${originalFileName}`;
+    formData.append('sourceUri', sourceUri);
+    formData.append('file', file, originalFileName);
 
     try {
+      clearPolling();
       const response = await fetch('/api/extract-cleanse-enrich-and-store', {
         method: 'POST',
         body: formData,
@@ -46,24 +60,39 @@ export default function Upload() {
     }
   };
 
-  const pollStatus = async (id) => {
-    const interval = setInterval(async () => {
+  const pollStatus = (id) => {
+    clearPolling();
+    pollingIntervalRef.current = setInterval(async () => {
       try {
         const response = await fetch(`/api/cleansed-data-status/${id}`);
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
         const newStatus = await response.text();
-        setStatus(`Processing status: ${newStatus}`);
-        if (newStatus === 'ENRICHMENT_COMPLETED' || newStatus.includes('FAILED') || newStatus.includes('ERROR')) {
-          clearInterval(interval);
+        const normalizedStatus = newStatus.trim();
+        setStatus(`Processing status: ${normalizedStatus}`);
+        const hasFailed = normalizedStatus.includes('FAILED') || normalizedStatus.includes('ERROR');
+        if (normalizedStatus === 'ENRICHMENT_COMPLETED' || hasFailed) {
+          clearPolling();
+          if (normalizedStatus === 'ENRICHMENT_COMPLETED') {
+            setFile(null);
+            if (fileInputRef.current) {
+              fileInputRef.current.value = '';
+            }
+          }
         }
       } catch (error) {
         console.error('Failed to poll status:', error);
-        clearInterval(interval);
+        clearPolling();
       }
     }, 2000);
   };
+
+  useEffect(() => {
+    return () => {
+      clearPolling();
+    };
+  }, []);
 
   return (
     <div>
@@ -80,8 +109,13 @@ export default function Upload() {
           </div>
           <div className="bg-white shadow-md rounded-lg p-8">
             <h1 className="text-2xl font-bold mb-4">Upload JSON File</h1>
-            <div className="flex items-center">
-              <input type="file" onChange={handleFileChange} className="border border-gray-300 rounded-lg p-2 mr-4" />
+              <div className="flex items-center">
+                <input
+                  type="file"
+                  onChange={handleFileChange}
+                  ref={fileInputRef}
+                  className="border border-gray-300 rounded-lg p-2 mr-4"
+                />
               <button onClick={handleUpload} disabled={isLoading} className="bg-blue-600 text-white font-bold py-2 px-4 rounded-lg">
                 {isLoading ? 'Uploading...' : 'Upload'}
               </button>


### PR DESCRIPTION
Update upload flow to correctly set `source_uri` to `file-upload:FILENAME.JSON` and harden status polling to clear files and stop continuous backend selects.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3713229-0adf-4160-86e2-725a02a66774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a3713229-0adf-4160-86e2-725a02a66774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

